### PR TITLE
Use email-aliases-plugin to find authors User objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mail-aliases</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <version>1.3</version>
             <scope>test</scope>


### PR DESCRIPTION
Users often have multiple email addresses that they use to commit changes in Git. It is not always the case that a users committer email and Jenkins email will be the same.

`email-aliases-plugin` allows a User to defined a set of email addresses that are related to their identity. When we run autofavorite we should use these addresses to help more accurately discover the user to assign the favorite to.

This PR depends on the initial commit of the `email-aliases-plugin` so it should be reviewed in conjunction with this PR. See https://github.com/i386/email-aliases-plugin/pull/1.
