### PR TITLE
JENKINS-43400 Bail out early if the workspace does not exist or is a …

### DIFF
--- a/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
+++ b/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
@@ -53,6 +53,12 @@ public class FavoritingScmListener extends SCMListener {
             return;
         }
 
+        // Bail out if the workspace does not exist or is not a directory
+        if (!workspace.exists() || !workspace.isDirectory()) {
+            LOGGER.fine("Workspace '" + workspace.getRemote() + "' does not exist or is a directory. Favoriting cannot be run.");
+            return;
+        }
+
         BuildData buildData = build.getAction(BuildData.class);
         Revision lastBuiltRevision = buildData.getLastBuiltRevision();
         if (lastBuiltRevision == null) {


### PR DESCRIPTION
…directory

When the workspace does not exist you end up with a lot of this in your log:
```
Apr 17, 2017 3:06:27 PM SEVERE io.jenkins.blueocean.autofavorite.FavoritingScmListener onCheckout
Unexpected error when retrieving changeset
hudson.plugins.git.GitException: Error launching git whatchanged
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$6.execute(CliGitAPIImpl.java:856)
	at io.jenkins.blueocean.autofavorite.FavoritingScmListener.getChangeSet(FavoritingScmListener.java:137)
	at io.jenkins.blueocean.autofavorite.FavoritingScmListener.onCheckout(FavoritingScmListener.java:67)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:123)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:83)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:73)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
	at hudson.security.ACL.impersonate(ACL.java:221)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Process working directory '/var/lib/jenkins/workspace/dp-ops_dp-openresty_PR-5-B473PJOCVHSFT2UDTFSJGRSVZPDUGCJJMZTF5A4LO6VECI3Q4YSQ@2/libLoader' doesn't exist!
	at hudson.Proc$LocalProc.<init>(Proc.java:243)
	at hudson.Proc$LocalProc.<init>(Proc.java:214)
	at hudson.Launcher$LocalLauncher.launch(Launcher.java:846)
	at hudson.Launcher$ProcStarter.start(Launcher.java:384)
	at hudson.Launcher$ProcStarter.join(Launcher.java:395)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$6.execute(CliGitAPIImpl.java:853)
	... 13 more

Apr 17, 2017 3:06:30 PM INFO org.jenkinsci.plugins.workflow.job.WorkflowRun finish
dp-ops/dp-openresty/PR-5 #1 completed: FAILURE
```

@reviewbybees