### PR TITLE
[JENKINS-43400] Print the error to the build log rather than swallowing it

### DIFF
--- a/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
+++ b/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
@@ -70,13 +70,13 @@ public class FavoritingScmListener extends SCMListener {
         // Sometimes the Git repository isn't consistent so we need to retry (JENKINS-39704)
         GitChangeSet first;
         try {
-            first = getChangeSet(gitSCM, workspace, lastBuiltRevision);
+            first = getChangeSet(gitSCM, workspace, lastBuiltRevision, listener);
         } catch (GitException e) {
             if (e.getCause() instanceof MissingObjectException) {
                 // Wait before we retry...
                 Thread.sleep(TimeUnit.SECONDS.toMillis(2));
                 try {
-                    first = getChangeSet(gitSCM, workspace, lastBuiltRevision);
+                    first = getChangeSet(gitSCM, workspace, lastBuiltRevision, listener);
                 } catch (GitException ex) {
                     LOGGER.log(Level.SEVERE, "Git repository is not consistent. Can't get the changeset that was just checked out.", ex);
                     first = null;
@@ -119,8 +119,8 @@ public class FavoritingScmListener extends SCMListener {
         }
     }
 
-    private GitChangeSet getChangeSet(GitSCM scm, FilePath workspace, Revision lastBuiltRevision) throws IOException, InterruptedException {
-        Git gitBuilder = Git.with(TaskListener.NULL, new EnvVars())
+    private GitChangeSet getChangeSet(GitSCM scm, FilePath workspace, Revision lastBuiltRevision, TaskListener listener) throws IOException, InterruptedException {
+        Git gitBuilder = Git.with(listener, new EnvVars())
                 .in(workspace);
 
         GitTool tool = scm.resolveGitTool(new LogTaskListener(LOGGER, Level.FINE));


### PR DESCRIPTION
Now when reproducing [JENKINS-43400](https://issues.jenkins-ci.org/browse/JENKINS-43400) according to instructions, you will see for example

```
…
Obtained Jenkinsfile from 59c3e61135c26f53e88d8420e6cf54840747e60d
Loading library tools@master
…
Checking out Revision 7436f27280bc1a007bbccf2e46cb98f62d31fb8b (master)
…
Loading library testResult@master
…
Checking out Revision f2ac4aad52aa18109585c2f7b6c999bc5e0a4721 (master)
…
First time build. Skipping changelog.
fatal: bad object 7436f27280bc1a007bbccf2e46cb98f62d31fb8b
…
[Pipeline] checkout
…
First time build. Skipping changelog.
fatal: bad object 7436f27280bc1a007bbccf2e46cb98f62d31fb8b
…
[longerTests]  > git checkout -f 59c3e61135c26f53e88d8420e6cf54840747e60d
[longerTests] fatal: bad object 7436f27280bc1a007bbccf2e46cb98f62d31fb8b
…
```

which makes the problem quite apparent: the plugin as written cannot work. It is assuming that the `SCM` passed to `SCMListener.onCheckout` can offer information on `BuildData.getLastBuiltRevision()`. In this case _one_ of the `BuildData`s would in fact be appropriate, but the plugin is always fetching the first one, even when processing checkouts from unrelated repositories.

I suspect you want to drop the `workflow-job` dependency (completely gratuitous), look for `SCMRevisionAction` on the build rather than `BuildData` (so we see what the actual `Jenkinsfile` revision was), then check for either a `AbstractGitSCMSource.SCMRevisionImpl` or `PullRequestSCMRevision`. Perhaps. I am assuming that is what you are interested in; it is not clear to me what your goal is in this plugin: the behavior seems rather vague.

@reviewbybees