### PR TITLE
Upgrade to git 3.6.0 and other workflow-* plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.17</version>
+        <version>2.35</version>
     </parent>
 
     <artifactId>blueocean-autofavorite</artifactId>
@@ -17,7 +17,8 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.7.1</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <scm>
@@ -46,34 +47,59 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.0</version>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.4.2</version>
+            <version>3.6.0</version>
+            <exclusions>
+                <!-- Upper bound dependencies error fix -->
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>1.10</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
-            <version>2.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>1.3</version>
+            <version>2.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.9.2</version>
+            <version>2.16</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>2.27</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Upper bound dependencies error fix -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.21</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
             <version>2.0.11</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.22</version>
+        </dependency>
+        <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
             <version>2.3.1</version>
@@ -78,6 +83,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>1.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
             <version>2.6</version>
@@ -85,8 +96,20 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
             <version>2.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.34</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
+++ b/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
@@ -3,23 +3,18 @@ package io.jenkins.blueocean.autofavorite;
 import hudson.model.Result;
 import hudson.model.User;
 import hudson.plugins.favorite.Favorites;
+import java.util.concurrent.TimeUnit;
 import jenkins.branch.BranchSource;
 import jenkins.branch.MultiBranchProject.BranchIndexing;
 import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class FavoritingScmListenerTest {
     @Rule
@@ -45,7 +40,10 @@ public class FavoritingScmListenerTest {
 
     private WorkflowJob createAndRunPipeline() throws java.io.IOException, InterruptedException {
         WorkflowMultiBranchProject mbp = j.createProject(WorkflowMultiBranchProject.class, "WorkflowMultiBranchProject");
-        mbp.getSourcesList().add(new BranchSource(new GitSCMSource(null, "https://github.com/i386/feedle.git", "", "*", "", true)));
+        GitSCMSource gitSCMSource = new GitSCMSource("https://github.com/i386/feedle.git");
+        gitSCMSource.setCredentialsId("");
+        gitSCMSource.getTraits().add(new BranchDiscoveryTrait());
+        mbp.getSourcesList().add(new BranchSource(gitSCMSource));
 
         BranchIndexing<WorkflowJob, WorkflowRun> indexing = mbp.getIndexing();
         indexing.run();


### PR DESCRIPTION
@i386 @michaelneale @stephenc there is test failing in PCT. 

[This test](https://github.com/jenkinsci/blueocean-autofavorite-plugin/blob/36957e41b242da305fc55b88fa9589b6f527874c/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java#L43) creates a multi-branch project and expects [FavoritingScmListener.onCheckout()](https://github.com/jenkinsci/blueocean-autofavorite-plugin/blob/398fc00bc2d4b3caab4d62dd347a43147103ed6d/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java#L47) to get called, but it never gets called and test fails.

This gets printed. Its missing logs from `FavoritingScmListener.onCheckout()`. 

```
=== Starting testAutoFavoriteForRegisteredUser(io.jenkins.blueocean.autofavorite.FavoritingScmListenerTest)
Nov 09, 2017 7:33:33 PM jenkins.branch.MultiBranchProject$BranchIndexing run
INFO: WorkflowMultiBranchProject #20171109.193330 branch indexing action completed: SUCCESS in 2.3 sec
Nov 09, 2017 7:33:36 PM org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: WorkflowMultiBranchProject/master #1 completed: FAILURE
Nov 09, 2017 7:33:36 PM org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: WorkflowMultiBranchProject/bob #1 completed: FAILURE
Nov 09, 2017 7:33:36 PM org.eclipse.jetty.server.AbstractConnector doStop
INFO: Stopped ServerConnector@a4add54{HTTP/1.1}{localhost:0}
Nov 09, 2017 7:33:36 PM org.eclipse.jetty.server.handler.ContextHandler doStop

java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at io.jenkins.blueocean.autofavorite.FavoritingScmListenerTest.testAutoFavoriteForRegisteredUser(FavoritingScmListenerTest.java:29)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:533)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

Before upgrade to git 3.6.0 and other workflow-* plugins it used to print:

```
Nov 09, 2017 7:23:45 PM jenkins.branch.MultiBranchProject$BranchIndexing run
INFO: WorkflowMultiBranchProject #20171109.192344 branch indexing action completed: SUCCESS in 1.5 sec
Nov 09, 2017 7:23:47 PM io.jenkins.blueocean.autofavorite.FavoritingScmListener onCheckout
INFO: Automatically favorited WorkflowMultiBranchProject/bob for jdumay
Nov 09, 2017 7:23:47 PM io.jenkins.blueocean.autofavorite.FavoritingScmListener onCheckout
INFO: Automatically favorited WorkflowMultiBranchProject/master for jdumay
Nov 09, 2017 7:23:48 PM org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: WorkflowMultiBranchProject/bob #1 completed: FAILURE
Nov 09, 2017 7:23:48 PM org.jenkinsci.plugins.workflow.job.WorkflowRun finish
INFO: WorkflowMultiBranchProject/master #1 completed: FAILURE
Nov 09, 2017 7:23:49 PM org.eclipse.jetty.server.AbstractConnector doStop
INFO: Stopped ServerConnector@1458ed9c{HTTP/1.1}{localhost:0}
Nov 09, 2017 7:23:49 PM org.eclipse.jetty.server.handler.ContextHandler doStop
```

@stephenc why would `SCMListener.onCheckout()` stopped getting called in this test after upgrading to git 3.6.0 and other workflow plugins? 
