### PR TITLE
JENKINS-47214 globally disable autofavorite using system property

### DIFF
--- a/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
+++ b/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
@@ -23,6 +23,7 @@ import hudson.scm.SCMRevisionState;
 import hudson.util.LogTaskListener;
 import io.jenkins.blueocean.autofavorite.user.FavoritingUserProperty;
 import jenkins.branch.MultiBranchProject;
+import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.errors.MissingObjectException;
 import org.jenkinsci.plugins.gitclient.Git;
@@ -46,6 +47,11 @@ public class FavoritingScmListener extends SCMListener {
 
     @Override
     public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState pollingBaseline) throws Exception {
+
+        if (!isEnabled()) {
+            return;
+        }
+
         // Look for the first build of a multibranch job
         if (!(build instanceof WorkflowRun
                 && ((WorkflowRun) build).getParent().getParent() instanceof MultiBranchProject
@@ -157,4 +163,10 @@ public class FavoritingScmListener extends SCMListener {
         }
         return Iterables.getOnlyElement(changeSets, null);
     }
+
+    static boolean isEnabled() {
+        return SystemProperties.getBoolean(BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY, true);
+    }
+
+    static final String BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY = "BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED";
 }

--- a/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
+++ b/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
@@ -13,6 +13,7 @@ import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -44,6 +45,27 @@ public class FavoritingScmListenerTest {
         User user = User.getById("jdumay", false);
         assertNotNull(user);
         assertFalse(Favorites.isFavorite(user, job));
+    }
+
+    @Test
+    public void testAutoFavoriteForRegisteredUserWhenGloballyDisabled() throws Exception {
+        User jdumay = User.getById("jdumay", true);
+        assertNotNull(jdumay);
+
+        // Disable autofavorite
+        assertTrue(FavoritingScmListener.isEnabled());
+        System.setProperty(FavoritingScmListener.BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY, "false");
+        assertFalse(FavoritingScmListener.isEnabled());
+
+        WorkflowJob job = createAndRunPipeline();
+        User user = User.getById("jdumay", false);
+        assertNotNull(user);
+        assertFalse(Favorites.isFavorite(user, job));
+    }
+
+    @After
+    public void enableFeature() {
+        System.setProperty(FavoritingScmListener.BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY, "true");
     }
 
 //    @Test


### PR DESCRIPTION
Administrators can pass the following system property to Jenkins to disabled autofavorite completely

```
-DBLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED=false
```