### PR TITLE
Updated the SCM configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
     </properties>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/blueocean-autofavorite-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/blueocean-autofavorite-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/blueocean-autofavorite-plugin</url>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
With this configuration the plugin can be used from the PCT toolkit.

```
18:01:33 Created plugin checkout dir : /jenkins/workspace/ATH/PCT-test-selector/work/blueocean-autofavorite
18:01:33 Checking out from SCM connection URL : scm:git:ssh://github.com/jenkinsci/blueocean-autofavorite-plugin.git (blueocean-autofavorite-1.1.0)
18:01:33 [INFO] Executing: /bin/sh -c cd '/jenkins/workspace/ATH/PCT-test-selector/work' && 'git' 'clone' 'ssh://github.com/jenkinsci/blueocean-autofavorite-plugin.git' '/jenkins/workspace/ATH/PCT-test-selector/work/blueocean-autofavorite'
18:01:33 [INFO] Working directory: /jenkins/workspace/ATH/PCT-test-selector/work
18:01:33 Error : The git-clone command failed. || Cloning into '/jenkins/workspace/ATH/PCT-test-selector/work/blueocean-autofavorite'...
18:01:33 Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.
18:01:33 Permission denied (publickey).
18:01:33 fatal: Could not read from remote repository.
18:01:33 
18:01:33 Please make sure you have the correct access rights
18:01:33 and the repository exists.
```

@reviewbybees 