### PR TITLE
[JENKINS-52704] DO-NOT-MERGE: Parent pom update 3.15 causes compile failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.35</version>
+        <version>3.15</version>
     </parent>
 
     <artifactId>blueocean-autofavorite</artifactId>


### PR DESCRIPTION
# DO NOT MERGE

See [JENKINS-52704](https://issues.jenkins-ci.org/browse/JENKINS-52704).

Ongoing plugin compat tester failures have shown that blueocean-autofavorite needs its parent POM updated to 3.15. After making this switch, the plugin will no longer build via `mvn clean install`:

```
[INFO] --- access-modifier-checker:1.15:enforce (default-enforce) @ blueocean-autofavorite ---
[ERROR] io/jenkins/blueocean/autofavorite/FavoritingScmListener:173 jenkins/util/SystemProperties must not be used
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6.645 s
[INFO] Finished at: 2018-07-23T10:09:12-04:00
[INFO] Final Memory: 174M/644M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.kohsuke:access-modifier-checker:1.15:enforce (default-enforce) on project blueocean-autofavorite: Access modifier checks failed. See the details above -> [Help 1]

```

That's because [this line](https://github.com/jenkinsci/blueocean-autofavorite-plugin/blob/fc97aaafc7c02e86be99bd55aee6324695f5d8aa/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java#L173) is attempting to use [the jenkins/util/SystemProperties class](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/util/SystemProperties.java#L68), which is marked as `@Restricted(NoExternalUse.class)`.