### PR TITLE
Java 11 readiness: Use recommended build configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,1 @@
-pipeline {
-  agent { docker 'maven' }
-  stages {
-    stage('build') {
-      steps {
-        sh 'mvn clean install' 
-      }
-    }
-  }
-}
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.14.1</version>
+            <version>2.32</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -63,68 +63,73 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.0.11</version>
+            <artifactId>git-client</artifactId>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>favorite</artifactId>
             <version>2.3.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>2.2.2</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
             <version>1.2.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.13</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.16</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <version>1.34</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>2.27</version>
-            <scope>test</scope>
+            <exclusions>
+                <!-- Pulled by JTH -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Upper bound dependencies error fix -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.21</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>command-launcher</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+                <version>2.2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-scm-step</artifactId>
+                <version>2.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>structs</artifactId>
+                <version>1.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.39</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <repositories>
         <repository>
         <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.35</version>
+        <version>3.40</version>
     </parent>
 
     <artifactId>blueocean-autofavorite</artifactId>

--- a/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
+++ b/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
@@ -23,7 +23,6 @@ import hudson.scm.SCMRevisionState;
 import hudson.util.LogTaskListener;
 import io.jenkins.blueocean.autofavorite.user.FavoritingUserProperty;
 import jenkins.branch.MultiBranchProject;
-import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.errors.MissingObjectException;
 import org.jenkinsci.plugins.gitclient.Git;
@@ -170,7 +169,11 @@ public class FavoritingScmListener extends SCMListener {
     }
 
     static boolean isEnabled() {
-        return SystemProperties.getBoolean(BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY, true);
+        String value = System.getProperty(BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY);
+        if (value != null) {
+            return Boolean.valueOf(value);
+        }
+        return true;
     }
 
     static final String BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY = "BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED";

--- a/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
+++ b/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -78,8 +79,8 @@ public class FavoritingScmListenerTest {
         System.setProperty(FavoritingScmListener.BLUEOCEAN_FEATURE_AUTOFAVORITE_ENABLED_PROPERTY, "true");
     }
 
-//    @Test
-    /** Disabled because of https://issues.jenkins-ci.org/browse/JENKINS-39694 **/
+    @Ignore("JENKINS-39694")
+    @Test
     public void testAutoFavoriteForNonRegisteredUser() throws Exception {
         assertNull(User.getById("jdumay", false));
         WorkflowJob job = createAndRunPipeline();

--- a/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
+++ b/src/test/java/io/jenkins/blueocean/autofavorite/FavoritingScmListenerTest.java
@@ -69,9 +69,11 @@ public class FavoritingScmListenerTest {
     public void testAutoFavoriteNullBuildData() throws Exception {
         User.getById("jdumay", true);
         WorkflowJob job = createAndRunPipeline(true);
+        WorkflowRun build = job.getBuildByNumber(1);
+        assertTrue("Build shouldn't have any data", build.getActions(BuildData.class).isEmpty());
         User user = User.getById("jdumay", false);
         assertNotNull(user);
-        assertFalse(Favorites.isFavorite(user, job));
+        assertFalse("User shouldn't have any favorite", Favorites.isFavorite(user, job));
     }
 
     @After
@@ -119,7 +121,7 @@ public class FavoritingScmListenerTest {
         while (run.getResult() == null) {
             /* poll faster as long as we still need to removeBuildData */
             if (removeBuildData) {
-                removeBuildData = !run.removeActions(BuildData.class);
+                run.removeActions(BuildData.class);
                 Thread.sleep(5);
             } else {
                 Thread.sleep(TimeUnit.SECONDS.toMillis(1));


### PR DESCRIPTION
For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.

@jenkinsci/java11-support 
