### PR TITLE
[JENKINS-43400] Use a more relevant logging level

### DIFF
--- a/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
+++ b/src/main/java/io/jenkins/blueocean/autofavorite/FavoritingScmListener.java
@@ -93,7 +93,7 @@ public class FavoritingScmListener extends SCMListener {
                     first = null;
                 }
             } else {
-                LOGGER.log(Level.SEVERE, "Unexpected error when retrieving changeset", e);
+                LOGGER.log(Level.WARNING, "Unexpected error when retrieving changeset", e);
                 first = null;
             }
         }


### PR DESCRIPTION
As this particular error generally isn't the result of something severe, I've reduced the logging level to "warning" instead.

This will also reduce noise and make it easier to see the truly `Severe` logs on Jenkins.

For more context, please see [the comments](https://issues.jenkins-ci.org/browse/JENKINS-43400?focusedCommentId=373810&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-373810) on JENKINS-43400.

_(**NOTE:** This PR **does not** close the referenced issue.)_