### PR TITLE
Adds auto-favoriting exclusion for workflow libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
         [ platform: "linux", jdk: "8" ],
         [ platform: "windows", jdk: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: "2.222.3" ]
+        [ platform: "linux", jdk: "11" ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <java.level>8</java.level>
     <!-- jenkins -->
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.289.3</jenkins.version>
     <!-- security spotbugs -->
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -54,14 +54,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.6.0</version>
-      <exclusions>
-        <!-- Upper bound dependencies error fix -->
-        <exclusion>
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -70,7 +62,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.0.11</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
@@ -81,26 +72,18 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.2.2</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- Pulled by JTH -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>pipeline-groovy-lib</artifactId>
+      <version>591.v3a_7f422b_d058</version>
+      <optional>true</optional>
     </dependency>
     <!-- Upper bound dependencies error fix -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>command-launcher</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -109,16 +92,10 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.176.x</artifactId>
-        <version>9</version>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1500.ve4d05cd32975</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/io/jenkins/blueocean/autofavorite/WorkFlowLibrariesTest.java
+++ b/src/test/java/io/jenkins/blueocean/autofavorite/WorkFlowLibrariesTest.java
@@ -1,0 +1,202 @@
+package io.jenkins.blueocean.autofavorite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.Result;
+import hudson.model.User;
+import hudson.plugins.favorite.Favorites;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import hudson.plugins.git.GitSCM;
+import jenkins.branch.BranchSource;
+import jenkins.branch.MultiBranchProject.BranchIndexing;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.libs.FolderLibraries;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class WorkFlowLibrariesTest {
+
+	@Rule
+	public TemporaryFolder folder= new TemporaryFolder();
+
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
+
+	private Path jobRepository;
+	private Path libraryRepository;
+
+	@Before
+	public void setUp() throws Exception {
+
+		GitSCM.ALLOW_LOCAL_CHECKOUT = true;
+
+		jobRepository = folder.newFolder().toPath();
+		libraryRepository = folder.newFolder().toPath();
+
+		createJobRepository(jobRepository);
+		createLibraryRepository(libraryRepository);
+
+	}
+
+	@Test
+	public void testGlobal() throws Exception {
+
+		setupGlobalLibraries(libraryRepository);
+
+		assertNull(User.getById("name1", false));
+		assertNull(User.getById("name2", false));
+		User.getById("name1", true);
+		User.getById("name2", true);
+
+		final WorkflowMultiBranchProject project = createWorkflowMultiBranchProject(jobRepository);
+		project.addProperty(createFolderLibraries(libraryRepository));
+		final WorkflowJob job = runPipeline(project);
+
+		final User name1 = User.getById("name1", false);
+		assertNotNull(name1);
+		assertTrue(Favorites.isFavorite(name1, job));
+
+		final User name2 = User.getById("name2", false);
+		assertNotNull(name2);
+		assertFalse(Favorites.isFavorite(name2, job));
+
+	}
+
+
+	@Test
+	public void testFolder() throws Exception {
+
+		assertNull(User.getById("name1", false));
+		assertNull(User.getById("name2", false));
+		User.getById("name1", true);
+		User.getById("name2", true);
+
+		final WorkflowMultiBranchProject project = createWorkflowMultiBranchProject(jobRepository);
+		project.addProperty(createFolderLibraries(libraryRepository));
+		final WorkflowJob job = runPipeline(project);
+
+		final User name1 = User.getById("name1", false);
+		assertNotNull(name1);
+		assertTrue(Favorites.isFavorite(name1, job));
+
+		final User name2 = User.getById("name2", false);
+		assertNotNull(name2);
+		assertFalse(Favorites.isFavorite(name2, job));
+
+	}
+
+	private WorkflowMultiBranchProject createWorkflowMultiBranchProject(final Path jobRepository) throws java.io.IOException, InterruptedException {
+		WorkflowMultiBranchProject mbp = j.createProject(WorkflowMultiBranchProject.class, "WorkflowMultiBranchProject");
+		GitSCMSource gitSCMSource = new GitSCMSource(jobRepository.toString());
+		gitSCMSource.setCredentialsId("");
+		gitSCMSource.getTraits().add(new BranchDiscoveryTrait());
+		mbp.getSourcesList().add(new BranchSource(gitSCMSource));
+
+		return mbp;
+	}
+
+	private WorkflowJob runPipeline(final WorkflowMultiBranchProject mbp) throws java.io.IOException, InterruptedException {
+		BranchIndexing<WorkflowJob, WorkflowRun> indexing = mbp.getIndexing();
+		indexing.run();
+
+		while (indexing.getResult() == Result.NOT_BUILT) {
+			Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+		}
+
+		assertEquals(Result.SUCCESS,  indexing.getResult());
+
+		WorkflowJob job = mbp.getItem("master");
+		while (job.getBuilds().isEmpty()) {
+			Thread.sleep(5);
+		}
+
+		WorkflowRun run = job.getBuildByNumber(1);
+		assertNotNull(run);
+
+		while (run.getResult() == null) {
+			/* poll faster as long as we still need to removeBuildData */
+			Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+		}
+
+		return job;
+	}
+
+	private void setupGlobalLibraries(final Path libraryRepository) {
+		List<LibraryConfiguration> libraries = new ArrayList<>();
+		GitSCMSource scmSource = new GitSCMSource(libraryRepository.toString());
+		SCMSourceRetriever scmSourceRetriever = new SCMSourceRetriever(scmSource);
+		final LibraryConfiguration libraryConfiguration = new LibraryConfiguration(
+			"shared-library",
+			scmSourceRetriever);
+		libraryConfiguration.setDefaultVersion("master");
+		libraries.add(libraryConfiguration);
+		GlobalLibraries.get().setLibraries(libraries);
+	}
+
+	private FolderLibraries createFolderLibraries(final Path libraryRepository) {
+		List<LibraryConfiguration> libraries = new ArrayList<>();
+		GitSCMSource scmSource = new GitSCMSource(libraryRepository.toString());
+		SCMSourceRetriever scmSourceRetriever = new SCMSourceRetriever(scmSource);
+		final LibraryConfiguration libraryConfiguration = new LibraryConfiguration(
+				"shared-library",
+				scmSourceRetriever);
+		libraryConfiguration.setDefaultVersion("master");
+		libraries.add(libraryConfiguration);
+		return new FolderLibraries(libraries);
+	}
+
+	private void createJobRepository(final Path path) throws IOException, GitAPIException {
+		Files.copy(getClass().getResourceAsStream("/job-repository/Jenkinsfile"),
+				   path.resolve("Jenkinsfile"));
+
+		try (Git git = Git.init().setDirectory(path.toFile()).call()) {
+
+			git.add().addFilepattern("Jenkinsfile").call();
+
+			git.commit()
+			   .setMessage("some commit message 1")
+			   .setAuthor("name1", "name1@example.com")
+			   .call();
+		}
+	}
+
+	private void createLibraryRepository(final Path path) throws IOException, GitAPIException {
+		final Path vars = path.resolve("vars");
+		vars.toFile().mkdir();
+
+		Files.copy(getClass().getResourceAsStream("/library-repository/vars/helloWorld.groovy"),
+				   vars.resolve("helloWorld.groovy"));
+
+		try (Git git = Git.init().setDirectory(path.toFile()).call()) {
+
+			git.add().addFilepattern("vars/helloWorld.groovy").call();
+
+			git.commit()
+			   .setMessage("some commit message 2")
+			   .setAuthor("name2", "name2@example.com")
+			   .call();
+		}
+	}
+}

--- a/src/test/resources/job-repository/Jenkinsfile
+++ b/src/test/resources/job-repository/Jenkinsfile
@@ -1,0 +1,18 @@
+@Library("shared-library") _
+
+pipeline {
+   agent any
+
+   stages {
+      stage('Hello') {
+         steps {
+            echo 'Hello World'
+         }
+      }
+      stage('Hello from library') {
+         steps {
+            helloWorld()
+         }
+      }
+   }
+}

--- a/src/test/resources/library-repository/vars/helloWorld.groovy
+++ b/src/test/resources/library-repository/vars/helloWorld.groovy
@@ -1,0 +1,3 @@
+def call(Map config = [:]) {
+    sh "echo Hello ${config.name}. Today is ${config.dayOfWeek}."
+}


### PR DESCRIPTION
Without testing if a remote URL is a match for the buildData it might log an error when testing a specific commit against the wrong git repository: Unexpected error when retrieving changeset
hudson.plugins.git.GitException: Error: git whatchanged --no-abbrev ... Should fix [JENKINS-43400 Autofavorite broken on remote agents](https://issues.jenkins.io/browse/JENKINS-43400).

Fixing the previous behavior leads to auto-favoriting the author of the last commit for the workflow library for all builds that contains the workflow library.

Bumps supported Jenkins to 2.289.3, required by pipeline-groovy-lib.

pipeline-groovy-lib contains duplicate code from deprecated plugin workflow-cps-global-lib-plugin. Could not add support for both plugins due the java package being the same. 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
